### PR TITLE
Expose direct URL of single chart

### DIFF
--- a/assets/js/indikatoren-filter.js
+++ b/assets/js/indikatoren-filter.js
@@ -134,8 +134,8 @@ function getSortOptions(name){
 function preparePortalView(){
   $("#main-control-element-indikatorenset").remove();    
   renderThema();
-  renderMultiselectDropdownFromJson(indikatoren, 'schlagwort', '#schlagwort_filter');    
-  renderMultiselectDropdownFromJson(["Schweiz", "Kanton", "Gemeinde", "Wohnviertel", "Bezirk", "Block", "Blockseite"], '', '#raeumlicheGliederung_filter');
+  renderMultiselectDropdownFromJson(indikatoren, 'schlagwort', '#schlagwort_filter', true);    
+  renderMultiselectDropdownFromJson(["Schweiz", "Kanton", "Gemeinde", "Wohnviertel", "Bezirk", "Block", "Blockseite"], '', '#raeumlicheGliederung_filter', false);
 
   //prepare query String object for filtering thema and unterthema
   var baseQuery = {};
@@ -272,13 +272,17 @@ function renderDropdownFromJson(data, field, selector, sortKey, filterQueryStrin
 
 
 //create a multi-select dropdown that contain values from a given json object at a specified place in the DOM 
-function renderMultiselectDropdownFromJson(data, field, selector){
+function renderMultiselectDropdownFromJson(data, field, selector, sort){
   var JQ = JsonQuery(data);
   var allValuesNested = JQ.pluck(field).all;
-  //reduce array of arrayy of values to array of values if applicable
+  //reduce array of array of values to array of values (flatMap) if applicable
   var allValues = [].concat.apply([], allValuesNested);
   //get unique values and filter out empty string 
   var uniqueValues = allValues.filter(function(item, i, ar){ return ar.indexOf(item) === i && item != ""; }); 
+  //sort if applicable
+  if (sort) {
+    uniqueValues.sort();
+  }
   var html = $('#option-template').html();
   var templateFunction = FilterJS.templateBuilder(html);
   var container = $(selector);

--- a/assets/js/indikatoren-highcharts.js
+++ b/assets/js/indikatoren-highcharts.js
@@ -74,6 +74,7 @@ function renderChart(globalOptionsUrl, templateUrl, chartUrl, csvUrl, kuerzel, c
       //draw chart
       var chart = new Highcharts['Chart'](options, callbackFn);
     }, chartOptions, data);      
+    
   };
 
 
@@ -85,7 +86,6 @@ function renderChart(globalOptionsUrl, templateUrl, chartUrl, csvUrl, kuerzel, c
     //make sure node exists before deferencing it
     options['exporting'] = (chartOptions['exporting'] || {});
     options['exporting']['filename'] = data.kuerzel;
-
   };
 };
 

--- a/charts/options001.js
+++ b/charts/options001.js
@@ -34,5 +34,10 @@ Highcharts.setOptions({
     }
 });
 //Add "Einbetten" menu item
-//todo: replace hard-coded url with $.url('protocol') + '://' + $.url('hostname') + $.url(1) + '/chart.html?kuerzel=' + this.renderTo.id.substring(10)
-Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({"text": "URL", "onclick": function(){ window.open('https://statabs.github.io/indikatoren/chart.html?kuerzel=' + this.renderTo.id.substring(10), '_blank'); }});
+Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push(
+    {
+        "text": "URL", 
+        "onclick": function(){
+            window.open($.url('protocol') + '://' + $.url('hostname') + ':' + $.url('port') + '/' + $.url(1) + '/chart.html?kuerzel=' + this.renderTo.id.substring(10), '_blank'); 
+        }
+    });

--- a/charts/options001.js
+++ b/charts/options001.js
@@ -19,7 +19,10 @@ Highcharts.setOptions({
         "buttons": {
             "contextButton": {
                 "text": "",
-                "menuItems": Highcharts.getOptions().exporting.buttons.contextButton.menuItems.slice(0, 7)                
+                "menuItems": Highcharts.getOptions().exporting.buttons.contextButton.menuItems.slice(0, 7)     
+                /*
+                Highcharts.getOptions().exporting.buttons.contextButton.menuItems.slice(0, 7).push({"textKey": "Test", "onclick": function(){ console.log('Test was clicked.'); }}) 
+                 */           
             }
         }
     },
@@ -30,3 +33,6 @@ Highcharts.setOptions({
         }
     }
 });
+//Add "Einbetten" menu item
+//todo: replace hard-coded url with $.url('protocol') + '://' + $.url('hostname') + $.url(1) + '/chart.html?kuerzel=' + this.renderTo.id.substring(10)
+Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({"text": "URL", "onclick": function(){ window.open('https://statabs.github.io/indikatoren/chart.html?kuerzel=' + this.renderTo.id.substring(10), '_blank'); }});


### PR DESCRIPTION
#48: In the chart's hamburger menu, we can now click "URL". This opens a new browser tab containing the chart. From this tab, the url can be copied and used in external systems (Email, iFrame, ...). 

@JE1982 Please provide feedback if functionality is ok for production. Test system resides [here](https://statabs-test.github.io/indikatoren/). 

![screen shot 2016-09-26 at 17 56 17](https://cloud.githubusercontent.com/assets/7261044/18841611/90c25574-8412-11e6-8c00-e1ff2b0a4e9e.png)

