### PR TITLE
add exporting:allowHTML:true to befragungenGrundauswertung001.js

### DIFF
--- a/charts/templates/befragungenGrundauswertung001.js
+++ b/charts/templates/befragungenGrundauswertung001.js
@@ -147,6 +147,9 @@
                 verticalAlign: "bottom",
                 x: 10
             }
+        },
+        exporting: {
+            allowHTML: true
         }
     };
 }());


### PR DESCRIPTION
to enable correct HTML-export of e.g. &nbsp; to SVG-images