### PR TITLE
introduce query string params to disable animations and context menu

### DIFF
--- a/build/createChartConfigs.js
+++ b/build/createChartConfigs.js
@@ -136,7 +136,7 @@ function saveChartConfig(indikator, view, console){
     
         var ctx = execute("assets/js/indikatoren-highcharts.js", {Highcharts: Highcharts, chartOptions: {},  geojson_wohnviertelEPSG2056: geojson_wohnviertelEPSG2056, geojson_wohnviertelEPSG2056_StadtBasel: geojson_wohnviertelEPSG2056_StadtBasel, rheinDataEPSG2056: rheinDataEPSG2056, scalebarDataEPSG2056: scalebarDataEPSG2056, scalebarDataTrinat: scalebarDataTrinat, borderDataTrinat: borderDataTrinat, geojson_gemeinden: geojson_gemeinden, console: console}).context;
         
-        ctx.createChartConfig(dataWithoutQuotes, options, template, indikator, view, true, function(options){
+        ctx.createChartConfig(dataWithoutQuotes, options, template, indikator, view, true, true, function(options){
             var stringifiedOptions = serialize(options, {space: 2});
             var filePath = 'charts/configs/' + view + '/';
             //var filePath = (isIndikatorensetView(view)) ? 'charts/configs/indikatorenset/' : 'charts/configs/portal/';

--- a/chart-details.html
+++ b/chart-details.html
@@ -205,6 +205,8 @@
       var hideErlaeuterungenTitle = window.decodeURIComponent($.url('?hideErlaeuterungenTitle')) === 'true';
       var hideLinks = window.decodeURIComponent($.url('?hideLinks')) === 'true';
       var hideLinksTitle = window.decodeURIComponent($.url('?hideLinksTitle')) === 'true';
+
+      var disableAnimations = window.decodeURIComponent($.url('?disableAnimations')) === 'true';
       
       //unhide header
       if (!hideHeader) { 
@@ -222,7 +224,7 @@
             var container = $('body');
             container.append(templateFunction(chartMetadata));
             //render chart. if header is hidden, remove left margin in callback
-            lazyRenderChartById(id, chartMetadata, view, true, (hideHeader ? removeLeftMargin : undefined));
+            lazyRenderChartById(id, chartMetadata, view, true, disableAnimations, (hideHeader ? removeLeftMargin : undefined));
         });
       }
       else {

--- a/chart.html
+++ b/chart.html
@@ -108,7 +108,7 @@ if (idByKuerzel[kuerzel] || kuerzelById[id] || templatesById[id]){
       //check if the chart's svg should be saved into a 2nd hidden div for casperjs
       var hiddenSVG = (window.decodeURIComponent($.url('?hiddenSVG')) === 'true') ? true : false;
   
-      lazyRenderChartById(id, chartMetadata, view, suppressNumberInTitle, function(){
+      lazyRenderChartById(id, chartMetadata, view, suppressNumberInTitle, false, function(){
         
         //make sure we have the complete chart with the renderTo object, which contains the kuerzel
         if (this.renderTo){                        

--- a/charts/templates/options001.js
+++ b/charts/templates/options001.js
@@ -2,12 +2,15 @@
     global $
 */
 
+var disableContextMenu = window.decodeURIComponent($.url('?disableContextMenu')) === 'true';
+
 Highcharts.setOptions({
 	"exporting": {
         "sourceWidth": null,
         "scale": 5,
         "buttons": {
             "contextButton": {
+              enabled: !disableContextMenu,
                 /*
                 "text": "",
                 "menuItems": Highcharts.getOptions().exporting.buttons.contextButton.menuItems.slice(0, 8),


### PR DESCRIPTION
During visual regression tests animations need to be turned off
in order to prevent capturing incomplete chart snapshots.

The `disableAnimations` query string param turns off
all chart animations. The parameter is only valid on chart-details.html
but not on chart.html.

Also add `disableContextMenu` to hide the context menu. This option
is applied globally and valid for:

* chart-details.html
* index.html
* chart.html
* chart-dev.html

Closes #2420